### PR TITLE
Create Terraform AWS provider configuration

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">=1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.35.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-1"
+  profile = "bball8bot-admin"
+}


### PR DESCRIPTION
Part of #9.

This diff creates the Terraform configuration for the AWS providers required for the API Gateway, SQS and Lambda AWS resources.