### PR TITLE
Create Lambda Terraform module

### DIFF
--- a/terraform/lambda/data.tf
+++ b/terraform/lambda/data.tf
@@ -1,0 +1,23 @@
+data "aws_iam_policy_document" "bball8bot_lambda_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "assume_bball8bot_lambda_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}

--- a/terraform/lambda/data.tf
+++ b/terraform/lambda/data.tf
@@ -21,3 +21,10 @@ data "aws_iam_policy_document" "assume_bball8bot_lambda_role" {
     }
   }
 }
+
+# Creates a zip file at the output path from the specified source file path.
+data "archive_file" "zipped_binary_for_deploy" {
+  type        = "zip"
+  source_file = local.binary_path
+  output_path = local.output_archive_path
+}

--- a/terraform/lambda/inputs.tf
+++ b/terraform/lambda/inputs.tf
@@ -1,0 +1,9 @@
+variable "lambda_name" {
+  description = "The name of the Lambda function"
+  type        = string
+}
+
+variable "handler_function_name" {
+  description = "The name of the golang handler function"
+  type        = string
+}

--- a/terraform/lambda/locals.tf
+++ b/terraform/lambda/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  # Ref: https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html#golang-package-mac-linux
+  # Note: golang executable binary has to be named bootstrap and output to this specific directory
+  binary_path         = "bin/bootstrap"
+  output_archive_path = "bin/main.zip"
+}

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -1,0 +1,11 @@
+resource "aws_iam_policy" "bball8bot_lambda_policy" {
+  name   = "bball8botLambdaPolicy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.bball8bot_lambda_policy.json
+}
+
+resource "aws_iam_role" "bball8bot_lambda_role" {
+  name                = "bball8botLambdaRole"
+  assume_role_policy  = data.aws_iam_policy_document.assume_bball8bot_lambda_role.json
+  managed_policy_arns = [aws_iam_policy.bball8bot_lambda_policy.arn]
+}

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -1,3 +1,14 @@
+resource "aws_lambda_function" "bball8bot_event_handler" {
+  function_name = var.lambda_name
+  handler       = var.handler_function_name
+
+  role = aws_iam_role.bball8bot_lambda_role.arn
+
+  # Ref: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-provided.html
+  runtime  = "provided.al2023"
+  filename = local.output_archive_path
+}
+
 resource "aws_iam_policy" "bball8bot_lambda_policy" {
   name   = "bball8botLambdaPolicy"
   path   = "/"


### PR DESCRIPTION
Part of #9. Supersedes #13.

This diff creates the Lambda Terraform module, for future use when provisioning the actual Lambda resource.