### PR TITLE
Provision Lambda resource

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -1,0 +1,5 @@
+cd src
+GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
+cd ../terraform
+terraform init
+terraform apply

--- a/plan.sh
+++ b/plan.sh
@@ -1,2 +1,5 @@
 cd src
 GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
+cd ../terraform
+terraform init
+terraform plan

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,5 @@
+module "lambda" {
+  source                = "./lambda"
+  lambda_name           = "bball8bot_event_handler"
+  handler_function_name = "main"
+}


### PR DESCRIPTION
Part of #9. Supersedes #13.

This diff provisions the Lambda resource; the resource state should be reflected in AWS once the configured plan is applied.