### PR TITLE
Create SQS Terraform module

### DIFF
--- a/terraform/sqs/inputs.tf
+++ b/terraform/sqs/inputs.tf
@@ -1,0 +1,9 @@
+variable "queue_name" {
+  description = "The name of the SQS queue"
+  type        = string
+}
+
+variable "is_fifo" {
+  description = "True if the SQS queue is FIFO, and false otherwise"
+  type        = bool
+}

--- a/terraform/sqs/main.tf
+++ b/terraform/sqs/main.tf
@@ -1,0 +1,9 @@
+resource "aws_sqs_queue" "bball8bot_event_queue" {
+  name                       = var.queue_name
+  delay_seconds              = 0
+  visibility_timeout_seconds = 30
+  max_message_size           = 1024
+  message_retention_seconds  = 60
+  receive_wait_time_seconds  = 2
+  sqs_managed_sse_enabled    = true
+}

--- a/terraform/sqs/outputs.tf
+++ b/terraform/sqs/outputs.tf
@@ -1,0 +1,3 @@
+output "queue_arn" {
+  value = aws_sqs_queue.bball8bot_event_queue.arn
+}


### PR DESCRIPTION
Part of #9, #20.

This diff creates the SQS Terraform module, for future use when provisioning the actual SQS resource.