### PR TITLE
Provision SQS resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,3 +3,9 @@ module "lambda" {
   lambda_name           = "bball8bot_event_handler"
   handler_function_name = "main"
 }
+
+module "sqs" {
+  source     = "./sqs"
+  queue_name = "bball8bot_event_queue"
+  is_fifo    = false
+}


### PR DESCRIPTION
Part of #9. Closes #20.

This diff provisions the SQS event queue; the queue's state should be reflected in AWS once the configured plan is applied.