### PR TITLE
Provision API Gateway resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,3 +9,8 @@ module "sqs" {
   queue_name = "bball8bot_event_queue"
   is_fifo    = false
 }
+
+module "api_gateway" {
+  source    = "./api_gateway"
+  queue_arn = module.sqs.queue_arn
+}


### PR DESCRIPTION
Closes https://github.com/jonleeyz/bball8bot/issues/21.

This diff provisions the API Gateway resource; state should be reflected in AWS once the configured plan is applied.