### PR TITLE
Create terraform.tfvars file

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -2,5 +2,4 @@ cd src
 GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
 cd ../terraform
 terraform init
-export TF_VAR_aws_region=ap-southeast-1
 terraform apply

--- a/plan.sh
+++ b/plan.sh
@@ -2,5 +2,4 @@ cd src
 GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
 cd ../terraform
 terraform init
-export TF_VAR_aws_region=ap-southeast-1
 terraform plan

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,1 @@
+aws_region = "ap-southeast-1"


### PR DESCRIPTION
This diff creates the terraform.tfars to store and set all environment variables.

Previously, this was done through automation scripts; this is potentially difficult to trace should there be a larger number of environment variables in the future. This way, it's all in one place.