### PR TITLE
Provision Secrets Manager resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,3 +20,8 @@ module "api_gateway" {
   queue_name = module.sqs.queue_name
   aws_region = var.aws_region
 }
+
+module "secrets_manager" {
+  source = "./secrets_manager"
+  telegram_bot_token = var.telegram_bot_token
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,3 +2,9 @@ variable "aws_region" {
   description = "The AWS region that that resources will be provisioned in, should any of them need to belong to one"
   type        = string
 }
+
+variable "telegram_bot_token" {
+  description = "The Telegram Bot API token for bball8bot"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Closes #39.

This diff provisions the Secrets Manager resource; state should be reflected in AWS once the configured plan is applied.