### PR TITLE
Migrate Terraform workspace state to S3

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -7,9 +7,17 @@ terraform {
       version = "5.35.0"
     }
   }
+
+  backend "s3" {
+    region = "ap-southeast-1"
+
+    bucket = "jl-terraform-remote-state-store"
+    key    = "bball8bot/terraform.tfstate"
+
+    dynamodb_table = "terraform_state_lock"
+  }
 }
 
 provider "aws" {
   region  = "ap-southeast-1"
-  profile = "bball8bot-admin"
 }


### PR DESCRIPTION
Closes #36.

This diff updates the Terraform provider configuration to store state in S3.