### PR TITLE
Specify SQS queue for Lambda IAM policy

### DIFF
--- a/terraform/iam/lambda_data.tf
+++ b/terraform/iam/lambda_data.tf
@@ -7,7 +7,6 @@ data "aws_iam_policy_document" "lambda_policy" {
       "logs:PutLogEvents",
     ]
 
-    # TODO @jonlee: Tighten scope
     resources = ["arn:aws:logs:*:*"]
   }
   statement {
@@ -26,7 +25,6 @@ data "aws_iam_policy_document" "lambda_policy" {
       "sqs:ListQueues"
     ]
 
-    # TODO @jonlee: Tighten scope
     resources = ["*"]
   }
 }


### PR DESCRIPTION
This diff adds the specific SQS queue the Lambda will be reading from in the Lambda IAM policy.

Good practice to scope permissions as narrowly as possible.