### PR TITLE
Add infra workspace bucket key

### DIFF
--- a/ci/terraform/data.tf
+++ b/ci/terraform/data.tf
@@ -12,7 +12,10 @@ data "aws_iam_policy_document" "terraform_state_management_policy" {
       "s3:PutObject",
     ]
 
-    resources = ["${local.state_store_bucket_arn}/${local.workspace_bucket_key}"]
+    resources = [
+      "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key}",
+      "${local.state_store_bucket_arn}/${local.ci_workspace_bucket_key}"
+    ]
   }
   statement {
     effect = "Allow"

--- a/ci/terraform/locals.tf
+++ b/ci/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
   github_oidc_provider_url = "token.actions.githubusercontent.com"
   state_store_bucket_arn = "arn:aws:s3:::jl-terraform-remote-state-store"
-  workspace_bucket_key     = "bball8bot/ci/terraform.tfstate"
+  infra_workspace_bucket_key     = "bball8bot/infra/terraform.tfstate"
+  ci_workspace_bucket_key     = "bball8bot/ci/terraform.tfstate"
   state_lock_table_arn = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
 }

--- a/ci/terraform/locals.tf
+++ b/ci/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  github_oidc_provider_url = "token.actions.githubusercontent.com"
-  state_store_bucket_arn = "arn:aws:s3:::jl-terraform-remote-state-store"
-  infra_workspace_bucket_key     = "bball8bot/infra/terraform.tfstate"
-  ci_workspace_bucket_key     = "bball8bot/ci/terraform.tfstate"
-  state_lock_table_arn = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
+  github_oidc_provider_url   = "token.actions.githubusercontent.com"
+  state_store_bucket_arn     = "arn:aws:s3:::jl-terraform-remote-state-store"
+  infra_workspace_bucket_key = "bball8bot/infra/terraform.tfstate"
+  ci_workspace_bucket_key    = "bball8bot/ci/terraform.tfstate"
+  state_lock_table_arn       = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
 }


### PR DESCRIPTION
The previous IAM policy for the IAM CI role did not include permissions to manage Terraform state for the infra workspace.

This diff adds the bucket key for the infra workspace, enabling state management.

Updates implementation for #62, as implemented in #60.