### PR TITLE
Create GitHub Action workflow: terraform plan on PR creation

### DIFF
--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -53,11 +53,10 @@ jobs:
           TF_VAR_telegram_bot_token: ${{ secrets.TF_VAR_TELEGRAM_BOT_TOKEN }}
         run: terraform plan -input=false
         if: github.event_name == 'pull_request'
-        continue-on-error: true
 
       - name: Report workflow output
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -1,0 +1,258 @@
+name: "CI/CD: On PR creation"
+on:
+  pull_request:
+permissions:
+      id-token: write       # Required for AWS OIDC connection
+      contents: read        # Required by actions/checkout
+      pull-requests: write  # Required by GitHub bot to create comments on PRs
+env:
+  TF_LOG: INFO
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+jobs:
+  terraform-plan-infra:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./infra/terraform
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+
+      - name: Assume CI AWS IAM role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHub-OIDC-TERRAFORM
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: terraform init
+        id: init
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME_INFRA}" -backend-config="region=${AWS_REGION}"
+
+      - name: terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -input=false
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+
+      - name: Report workflow output
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let output = `### CI workflow: Terraform plan
+
+            Commit: ${{ github.sha }}
+            Pushed by: @${{ github.actor }}
+            Action: \`${{ github.event_name }}\`
+
+            ---
+
+            #### Summary: \`infra\` Terraform workspace
+
+            1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
+            2. \`terraform init\`:  \`${{ steps.init.outcome }}\`
+            3. \`terraform validate\`:  \`${{ steps.validate.outcome }}\`
+            4. \`terraform plan\`:  \`${{ steps.plan.outcome }}\`
+
+            <details open><summary>Generated plan:</summary>
+
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            ---
+
+            `;
+
+            output = output.replace(/success/g, "success ✅")
+            output = output.replace(/failure/g, "failure ❌")
+
+            const debugInfo = `### Debug information
+
+            <details><summary>terraform fmt:</summary>
+
+            \`\`\`
+            ${{ steps.fmt.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform init:</summary>
+
+            \`\`\`
+            ${{ steps.init.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform validate:</summary>
+
+            \`\`\`
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            ---
+            Comment \`/terraform plan infra\` to regenerate the plan.
+            Comment \`/terraform apply infra\` to apply the generated plan.
+            `;
+
+            output = output.concat(debugInfo)
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+  terraform-plan-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./ci/terraform
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+
+      - name: Assume CI AWS IAM role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHub-OIDC-TERRAFORM
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: terraform init
+        id: init
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME_CI}" -backend-config="region=${AWS_REGION}"
+
+      - name: terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -input=false
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+
+      - name: Report workflow output
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let output = `### CI workflow: Terraform plan
+
+            Commit: ${{ github.sha }}
+            Pushed by: @${{ github.actor }}
+            Action: \`${{ github.event_name }}\`
+
+            ---
+
+            #### Summary: \`CI\` Terraform workspace
+
+            1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
+            2. \`terraform init\`:  \`${{ steps.init.outcome }}\`
+            3. \`terraform validate\`:  \`${{ steps.validate.outcome }}\`
+            4. \`terraform plan\`:  \`${{ steps.plan.outcome }}\`
+
+            <details open><summary>Generated plan:</summary>
+
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            ---
+
+            `;
+
+            output = output.replace(/success/g, "success ✅")
+            output = output.replace(/failure/g, "failure ❌")
+
+            const debugInfo = `### Debug information
+
+            <details><summary>terraform fmt:</summary>
+
+            \`\`\`
+            ${{ steps.fmt.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform init:</summary>
+
+            \`\`\`
+            ${{ steps.init.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform validate:</summary>
+
+            \`\`\`
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            ---
+            Comment \`/terraform plan ci\` to regenerate the plan.
+            Comment \`/terraform apply ci\` to apply the generated plan.
+            `;
+
+            output = output.concat(debugInfo)
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Lambda function handler Go executable
         id: go-build
         working-directory: ./src
-        run: GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../infra/terraform/bin/bootstrap main.go
+        run: GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../infra/terraform/bin/bootstrap -v main.go
 
       - name: Assume CI AWS IAM role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -19,6 +19,15 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+
+      - name: Build Lambda function handler Go executable
+        working-directory: ./src
+        run: GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../infra/terraform/bin/bootstrap main.go
+
       - name: Assume CI AWS IAM role
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -25,6 +25,7 @@ jobs:
           go-version: '1.21.x'
 
       - name: Build Lambda function handler Go executable
+        id: go-build
         working-directory: ./src
         run: GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../infra/terraform/bin/bootstrap main.go
 
@@ -79,10 +80,11 @@ jobs:
 
             #### Summary:
 
-            1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
-            2. \`terraform init\`:  \`${{ steps.init.outcome }}\`
-            3. \`terraform validate\`:  \`${{ steps.validate.outcome }}\`
-            4. \`terraform plan\`:  \`${{ steps.plan.outcome }}\`
+            1. \`go build\`:  \`${{ steps.go-build.outcome }}\`
+            2. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
+            3. \`terraform init\`:  \`${{ steps.init.outcome }}\`
+            4. \`terraform validate\`:  \`${{ steps.validate.outcome }}\`
+            5. \`terraform plan\`:  \`${{ steps.plan.outcome }}\`
 
             <details open><summary>Generated plan:</summary>
 
@@ -100,6 +102,16 @@ jobs:
             output = output.replace(/failure/g, "failure ❌")
 
             const debugInfo = `### Debug information
+
+            <details><summary>go build:</summary>
+
+            \`\`\`
+            ${{ steps.go-build.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
 
             <details><summary>terraform fmt:</summary>
 

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: ./infra/terraform
     steps:
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
         uses: actions/setup-go@v4
@@ -162,7 +162,7 @@ jobs:
         working-directory: ./ci/terraform
     steps:
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Assume CI AWS IAM role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: terraform plan
         id: plan
+        env:
+          TF_VAR_telegram_bot_token: ${{ secrets.TF_VAR_TELEGRAM_BOT_TOKEN }}
         run: terraform plan -input=false
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -40,8 +40,8 @@ jobs:
         id: init
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
-        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME_INFRA}" -backend-config="region=${AWS_REGION}"
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME_INFRA }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"
 
       - name: terraform validate
         id: validate
@@ -163,8 +163,8 @@ jobs:
         id: init
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
-        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME_CI}" -backend-config="region=${AWS_REGION}"
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME_CI }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"
 
       - name: terraform validate
         id: validate

--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let output = `### CI workflow: Terraform plan
+            let output = `### \`infra\` Terraform workspace: \`terraform plan\`
 
             Commit: ${{ github.sha }}
             Pushed by: @${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
             ---
 
-            #### Summary: \`infra\` Terraform workspace
+            #### Summary:
 
             1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
             2. \`terraform init\`:  \`${{ steps.init.outcome }}\`
@@ -183,7 +183,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let output = `### CI workflow: Terraform plan
+            let output = `### \`CI\` Terraform workspace: \`terraform plan\`
 
             Commit: ${{ github.sha }}
             Pushed by: @${{ github.actor }}
@@ -191,7 +191,7 @@ jobs:
 
             ---
 
-            #### Summary: \`CI\` Terraform workspace
+            #### Summary:
 
             1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
             2. \`terraform init\`:  \`${{ steps.init.outcome }}\`

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 */terraform/bin/
 */terraform/terraform.tfstate
 */terraform/terraform.tfstate.backup
+
+*.sh

--- a/apply.sh
+++ b/apply.sh
@@ -1,5 +1,0 @@
-cd src
-GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
-cd ../terraform
-terraform init
-terraform apply

--- a/ci/terraform/data.tf
+++ b/ci/terraform/data.tf
@@ -34,10 +34,50 @@ data "aws_iam_policy_document" "workspace_infra_policy" {
   statement {
     effect = "Allow"
     actions = [
-      // change
-      "s3:*",
-      "dynamodb:*",
-      "iam:*"
+      "iam:*",
+    ]
+
+    // TODO @jonlee: might want to scope more narrowly if possible
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "apigateway:*"
+    ]
+
+    resources = ["arn:aws:apigateway:*::/*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "sqs:*",
+    ]
+
+    resources = ["arn:aws:sqs:ap-southeast-1:574182556674:bball8bot_event_queue"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:*",
+    ]
+
+    resources = ["arn:aws:secretsmanager:ap-southeast-1:574182556674:secret:telegram_bot_token-aaEKZR"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:*"
     ]
 
     resources = ["*"]

--- a/plan.sh
+++ b/plan.sh
@@ -1,5 +1,0 @@
-cd src
-GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../terraform/bin/bootstrap main.go
-cd ../terraform
-terraform init
-terraform plan


### PR DESCRIPTION
Closes #49.

This diff creates a GitHub Action workflow that runs `terraform plan` on the two Terraform workspaces.
- `infra`: This workspace contains all resource configurations for `bball8bot` application logic.
- `CI`: This workspace contains all resource configurations for `bball8bot` CI workflows and Terraform state management overall.