### PR TITLE
Remove state lock table backend configurations from provider files

### DIFF
--- a/ci/terraform/providers.tf
+++ b/ci/terraform/providers.tf
@@ -9,7 +9,6 @@ terraform {
   }
 
   backend "s3" {
-    dynamodb_table = "terraform_state_lock"
   }
 }
 

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -9,12 +9,6 @@ terraform {
   }
 
   backend "s3" {
-    region = "ap-southeast-1"
-
-    bucket = "jl-terraform-remote-state-store"
-    key    = "bball8bot/infra/terraform.tfstate"
-
-    dynamodb_table = "terraform_state_lock"
   }
 }
 


### PR DESCRIPTION
This diff completes the initiative to shift to partial configurations for Terraform providers.

The state lock table backend configurations will be provided locally through scripts during execution time, or through GitHub secrets.