### PR TITLE
Create GitHub Action workflow: terraform apply on core dev branch push

### DIFF
--- a/.github/workflows/apply_on_plan.yml
+++ b/.github/workflows/apply_on_plan.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - develop
-      - add-apply-on-core-push
 permissions:
       id-token: write       # Required for AWS OIDC connection
       contents: read        # Required by actions/checkout

--- a/.github/workflows/apply_on_plan.yml
+++ b/.github/workflows/apply_on_plan.yml
@@ -1,0 +1,122 @@
+name: "CI/CD: On core branch push"
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - add-apply-on-core-push
+permissions:
+      id-token: write       # Required for AWS OIDC connection
+      contents: read        # Required by actions/checkout
+env:
+  TF_LOG: INFO
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+jobs:
+  terraform-apply-infra:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./infra/terraform
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+
+      - name: Build Lambda function handler Go executable
+        id: go-build
+        working-directory: ./src
+        run: GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ../infra/terraform/bin/bootstrap -v main.go
+
+      - name: Assume CI AWS IAM role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHub-OIDC-TERRAFORM
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: terraform init
+        id: init
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME_INFRA }}
+          AWS_STATE_LOCK_TABLE_NAME: ${{ secrets.AWS_STATE_LOCK_TABLE_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}" -backend-config="dynamodb_table=${AWS_STATE_LOCK_TABLE_NAME}"
+
+      - name: terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        env:
+          TF_VAR_telegram_bot_token: ${{ secrets.TF_VAR_TELEGRAM_BOT_TOKEN }}
+        run: terraform plan -input=false -out tf.plan -var="telegram_bot_token=${TF_VAR_telegram_bot_token}"
+
+      - name: terraform apply
+        id: apply
+        if: ${{ steps.plan.outcome }} == 'success'
+        run: terraform apply -auto-approve tf.plan
+
+  terraform-apply-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./ci/terraform
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+
+      - name: Assume CI AWS IAM role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHub-OIDC-TERRAFORM
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: terraform init
+        id: init
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME_CI }}
+          AWS_STATE_LOCK_TABLE_NAME: ${{ secrets.AWS_STATE_LOCK_TABLE_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}" -backend-config="dynamodb_table=${AWS_STATE_LOCK_TABLE_NAME}"
+
+      - name: terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -input=false -out tf.plan
+
+      - name: terraform apply
+        id: apply
+        if: ${{ steps.plan.outcome }} == 'success'
+        run: terraform apply -auto-approve tf.plan
+


### PR DESCRIPTION
Closes https://github.com/jonleeyz/bball8bot/issues/50.

This diff creates a GitHub Action workflow that applies the latest plan on the two Terraform workspaces when pushes are made to core development branches (`main`, `develop`)

- infra: This workspace contains all resource configurations for bball8bot application
- CI: This workspace contains all resource configurations for bball8bot CI workflows and Terraform state management overall.

---

Moving forward, all plans should be checked before they are landed into `develop`. The apply can then be handled by CI.