### PR TITLE
Update Lambda handler to handle SQS event object

### DIFF
--- a/infra/terraform/lambda/main.tf
+++ b/infra/terraform/lambda/main.tf
@@ -4,8 +4,9 @@ resource "aws_lambda_function" "bball8bot_event_handler" {
   role          = var.lambda_iam_role_arn
 
   # Ref: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-provided.html
-  runtime  = "provided.al2023"
-  filename = local.output_archive_path
+  runtime          = "provided.al2023"
+  filename         = local.output_archive_path
+  source_code_hash = data.archive_file.zipped_binary_for_deploy.output_base64sha256
 }
 
 ##### Enables Lambda event handler to be triggered by SQS events

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
@@ -10,11 +12,11 @@ type MyEvent struct {
 	Name string `json:"name"`
 }
 
-func HandleRequest(ctx context.Context, event *MyEvent) (*string, error) {
+func HandleRequest(ctx context.Context, event *events.SQSEvent) (*string, error) {
 	if event == nil {
 		return nil, fmt.Errorf("received nil event")
 	}
-	message := fmt.Sprintf("Hello %s!", event.Name)
+	message := fmt.Sprintf("Hello %v!", event.Records)
 	return &message, nil
 }
 


### PR DESCRIPTION
This diff replaces the template event object input in the Lambda handler with the `events.SQSEvent` object.

This is preparation for actual handling of input SQS events in the future.