### PR TITLE
Print SQS event object body into std out

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -17,6 +17,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) (*string, error)
 		return nil, fmt.Errorf("received nil event")
 	}
 	message := fmt.Sprintf("Hello %v!", event.Records)
+	fmt.Println(message)
 	return &message, nil
 }
 


### PR DESCRIPTION
This diff allows the SQS event body to be visible in CloudWatch logs by printing the body of the input SQS event object to the Lambda handler into std out.