### PR TITLE
Add source code hash to Lambda function Terraform config

### DIFF
--- a/infra/terraform/lambda/main.tf
+++ b/infra/terraform/lambda/main.tf
@@ -4,8 +4,9 @@ resource "aws_lambda_function" "bball8bot_event_handler" {
   role          = var.lambda_iam_role_arn
 
   # Ref: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-provided.html
-  runtime  = "provided.al2023"
-  filename = local.output_archive_path
+  runtime          = "provided.al2023"
+  filename         = local.output_archive_path
+  source_code_hash = data.archive_file.zipped_binary_for_deploy.output_base64sha256
 }
 
 ##### Enables Lambda event handler to be triggered by SQS events


### PR DESCRIPTION
This diff adds the source code hash configuration to the Lambda function handler.

This is required to ensure Terraform indicates that updates to the Lambda handler are required when the golang binary is updated.

---

This was a part of #72, which was reverted, for better-scoped commits.