### PR TITLE
Add AWS Secrets Manager Parameters and Secrets Extension layer to Lambda function Terraform config

### DIFF
--- a/infra/terraform/lambda/locals.tf
+++ b/infra/terraform/lambda/locals.tf
@@ -3,4 +3,8 @@ locals {
   # Note: golang executable binary has to be named bootstrap and output to this specific directory
   binary_path         = "bin/bootstrap"
   output_archive_path = "bin/main.zip"
+
+  # Ref: https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html#ps-integration-lambda-extensions-add
+  # Note: Region-specific
+  parameters_and_secrets_extension_layer_arn = "arn:aws:lambda:ap-southeast-1:044395824272:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11"
 }

--- a/infra/terraform/lambda/main.tf
+++ b/infra/terraform/lambda/main.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "bball8bot_event_handler" {
   runtime          = "provided.al2023"
   filename         = local.output_archive_path
   source_code_hash = data.archive_file.zipped_binary_for_deploy.output_base64sha256
+  layers           = [local.parameters_and_secrets_extension_layer_arn]
 }
 
 ##### Enables Lambda event handler to be triggered by SQS events


### PR DESCRIPTION
This allows the Lambda function handler to call Secrets Manager without use of the SDK and to cache the values for use.

Effectively, this allows for retrieval of the Telegram bot token without use of the Secrets Manager SDK.
