### PR TITLE
Allow Lambda IAM role to use Parameters and Secrets Lambda Extension

### DIFF
--- a/infra/terraform/iam/lambda_data.tf
+++ b/infra/terraform/iam/lambda_data.tf
@@ -27,6 +27,15 @@ data "aws_iam_policy_document" "lambda_policy" {
 
     resources = ["*"]
   }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "kms:Decrypt"
+    ]
+
+    resources = ["*"]
+  }
 }
 
 data "aws_iam_policy_document" "assume_lambda_role" {


### PR DESCRIPTION
This diff updates the Lambda execution role to have the required permissions to use the Parameters and Secrets Lambda extension.