### PR TITLE
Create command handler driver

### DIFF
--- a/src/internal/commands/driver_impl.go
+++ b/src/internal/commands/driver_impl.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// HandleBotCommand calls the appropriate bot command handler if there is a valid bot command contained
+// in the input Update object.
+func HandleBotCommand(ctx context.Context, bot *tgbotapi.BotAPI, update *tgbotapi.Update) error {
+	commandStringLiteral := update.Message.Command()
+	commandHandler, ok := handlerMap[commandStringLiteral]
+	if !ok {
+		return fmt.Errorf("command not found in handlerMap: %s", commandStringLiteral)
+	}
+
+	if err := commandHandler.Init(bot, update); err != nil {
+		return err
+	}
+
+	return commandHandler.Handle(ctx)
+}
+
+// Init intialises a command handler with references to an initialised Bot API and the input Update object.
+func (c *CommandHandlerImpl) Init(bot *tgbotapi.BotAPI, update *tgbotapi.Update) error {
+	if bot != nil {
+		return fmt.Errorf("error when initialising /%s command handler: input BotAPI object is nil", c.command)
+	}
+	c.bot = bot
+
+	if update == nil {
+		return fmt.Errorf("error when initialising /%s command handler: input Update object is nil", c.command)
+	}
+	c.update = update
+
+	return nil
+}

--- a/src/internal/commands/interface.go
+++ b/src/internal/commands/interface.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"context"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// TODO @jonlee: Improve this description
+// CommandHandler defines an abstraction layer to handle Telegram Bot Commands.
+type CommandHandler interface {
+	Init(bot *tgbotapi.BotAPI, update *tgbotapi.Update) error
+	Handle(ctx context.Context) error
+}

--- a/src/internal/commands/structs.go
+++ b/src/internal/commands/structs.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+var handlerMap map[string]CommandHandler = map[string]CommandHandler{}
+
+// CommandHandlerImpl contains the common components required by a CommandHandler interface implementation.
+type CommandHandlerImpl struct {
+	command string
+	bot     *tgbotapi.BotAPI
+	update  *tgbotapi.Update
+}

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 
+	"github.com/jonleeyz/bbball8bot/internal/commands"
 	"github.com/jonleeyz/bbball8bot/internal/json"
 	"github.com/jonleeyz/bbball8bot/internal/logging"
 	"github.com/jonleeyz/bbball8bot/internal/secrets"
@@ -44,7 +45,12 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			logging.LogUpdateObject(*update)
 		}
 
-		// set message to be reply to original message
+		// if message is command, call command handler
+		if update.Message.IsCommand() {
+			return commands.HandleBotCommand(ctx, bot, update)
+		}
+
+		// if message is not command, echo message as reply to original message
 		newReply := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
 		if _, err := bot.Send(newReply); err != nil {


### PR DESCRIPTION
Part of #103.

---

This diff creates the common command handling flow, with a main driver function as the entry point from the main Lambda handler.

Handling of all defined bot commands will be handled by the containing `commands` package.