### PR TITLE
Update poll message content to be parsed as Markdown V2

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -17,6 +17,7 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 	}
 
 	trainingPollMessageResponse := tgbotapi.NewMessage(h.update.Message.Chat.ID, trainingPollMessageContent)
+	trainingPollMessageResponse.ParseMode = "MarkdownV2"
 
 	if _, err := h.bot.Send(trainingPollMessageResponse); err != nil {
 		err = fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -40,4 +40,4 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return populatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "**Training: %s, %s, %s @ %s**\n---\n\n\n**Attending:**\n\n\n**Not attending:**\n\n\n**Checking availability:**\n\n\n**Yet to respond:**\n\n\n"
+const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"


### PR DESCRIPTION
Update on #113, part of #104.

Parse mode was missing, and poll message content was being printed as is, with no formatting.

This diff allows the poll message content to be parsed as Markdown V2 content.