### PR TITLE
Escape dashes in training poll messsage content

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jonleeyz/bbball8bot/internal/logging"
 
@@ -37,7 +38,9 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 		locationContent string = "NTU"
 	)
 	populatedTrainingPollTemplate := fmt.Sprintf(TRAINING_POLL_TEMPLATE, dayContent, dateContent, timeContent, locationContent)
-	return populatedTrainingPollTemplate, nil
+
+	escapeDashPopulatedTrainingPollTemplate := strings.Replace(populatedTrainingPollTemplate, "-", "\\-", -1)
+	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
 const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"


### PR DESCRIPTION
Fix to issue introduced in #114, part of #104.

CloudWatch error log:
```
{
    "errorMessage": "error when calling Telegram Bot API to send message: Bad Request: can't parse entities: Character '-' is reserved and must be escaped with the preceding '\\'",
    "errorType": "errorString"
}
```

This diff provides a fix to the above error: dash character literals in the poll message content need to be appropriately escaped.