### PR TITLE
Fix poll message Markdown v2 bold formatting

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -43,4 +43,4 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"
+const TRAINING_POLL_TEMPLATE = "*Training: %s, %s, %s @ %s*\n---\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"


### PR DESCRIPTION
Fixes issues introduced in #115, part of #104.

This diff corrects the Markdown V2 bold formatting in poll messages, so that they display as intended.