### PR TITLE
Enable command: /newtrainingpoll

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jonleeyz/bbball8bot/internal/logging"
 
@@ -37,7 +38,9 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 		locationContent string = "NTU"
 	)
 	populatedTrainingPollTemplate := fmt.Sprintf(TRAINING_POLL_TEMPLATE, dayContent, dateContent, timeContent, locationContent)
-	return populatedTrainingPollTemplate, nil
+
+	escapeDashPopulatedTrainingPollTemplate := strings.Replace(populatedTrainingPollTemplate, "-", "\\-", -1)
+	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
 const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -43,4 +43,4 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"
+const TRAINING_POLL_TEMPLATE = "*Training: %s, %s, %s @ %s*\n---\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -29,8 +29,14 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 
 // buildTrainingPollMessageContent builds the content string for a training poll message.
 func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Update) (string, error) {
-	var baseContent string = TRAINING_POLL_TEMPLATE
-	return baseContent, nil
+	var (
+		dayContent      string = "Saturday"
+		dateContent     string = "Mar 16, 2024"
+		timeContent     string = "0915 - 1215"
+		locationContent string = "NTU"
+	)
+	populatedTrainingPollTemplate := fmt.Sprintf(TRAINING_POLL_TEMPLATE, dayContent, dateContent, timeContent, locationContent)
+	return populatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "Training: %s, %s @ %s\n---\n\n\nAttending:\n\n\nNot attending:\n\n\nChecking availability:\n\n\nYet to respond:\n\n\n"
+const TRAINING_POLL_TEMPLATE = "**Training: %s, %s, %s @ %s**\n---\n\n\n**Attending:**\n\n\n**Not attending:**\n\n\n**Checking availability:**\n\n\n**Yet to respond:**\n\n\n"

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -43,4 +43,22 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "*Training: %s, %s, %s @ %s*\n---\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"
+const TRAINING_POLL_TEMPLATE = `*Training*
+*%s, %s, %s*
+%s*
+---
+
+
+*Attending:*
+
+
+*Not attending:*
+
+
+*Checking availability:*
+
+
+*Yet to respond:*
+
+
+`

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -17,6 +17,7 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 	}
 
 	trainingPollMessageResponse := tgbotapi.NewMessage(h.update.Message.Chat.ID, trainingPollMessageContent)
+	trainingPollMessageResponse.ParseMode = "MarkdownV2"
 
 	if _, err := h.bot.Send(trainingPollMessageResponse); err != nil {
 		err = fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)
@@ -39,4 +40,4 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return populatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = "**Training: %s, %s, %s @ %s**\n---\n\n\n**Attending:**\n\n\n**Not attending:**\n\n\n**Checking availability:**\n\n\n**Yet to respond:**\n\n\n"
+const TRAINING_POLL_TEMPLATE = "*bold \\* Training: %s, %s, %s @ %s*\n---\n\n\n*bold \\*Attending:*\n\n\n*bold \\*Not attending:*\n\n\n*bold \\*Checking availability:*\n\n\n*bold \\*Yet to respond:*\n\n\n"

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jonleeyz/bbball8bot/internal/logging"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// Handle initiates the handling flow for the "/newtrainingpoll" command.
+func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
+	trainingPollMessageContent, err := buildTrainingPollMessageContent(ctx, h.update)
+	if err != nil {
+		return err
+	}
+
+	trainingPollMessageResponse := tgbotapi.NewMessage(h.update.Message.Chat.ID, trainingPollMessageContent)
+
+	if _, err := h.bot.Send(trainingPollMessageResponse); err != nil {
+		err = fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)
+
+		logging.Printf(err.Error())
+		return err
+	}
+	return nil
+}
+
+// buildTrainingPollMessageContent builds the content string for a training poll message.
+func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Update) (string, error) {
+	var baseContent string = TRAINING_POLL_TEMPLATE
+	return baseContent, nil
+}
+
+const TRAINING_POLL_TEMPLATE = "Training: %s, %s @ %s\n---\n\n\nAttending:\n\n\nNot attending:\n\n\nChecking availability:\n\n\nYet to respond:\n\n\n"

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -43,22 +43,4 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 	return escapeDashPopulatedTrainingPollTemplate, nil
 }
 
-const TRAINING_POLL_TEMPLATE = `*Training*
-*%s, %s, %s*
-%s*
----
-
-
-*Attending:*
-
-
-*Not attending:*
-
-
-*Checking availability:*
-
-
-*Yet to respond:*
-
-
-`
+const TRAINING_POLL_TEMPLATE = "*Training: %s, %s, %s @ %s*\n---\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"

--- a/src/internal/commands/structs.go
+++ b/src/internal/commands/structs.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	BOT_COMMAND_START = "start"
+	BOT_COMMAND_START             = "start"
+	BOT_COMMAND_NEW_TRAINING_POLL = "newtrainingpoll"
 )
 
 var (
@@ -14,6 +15,11 @@ var (
 		BOT_COMMAND_START: &StartCommandHandlerImpl{
 			CommandHandlerImpl: CommandHandlerImpl{
 				command: BOT_COMMAND_START,
+			},
+		},
+		BOT_COMMAND_NEW_TRAINING_POLL: &NewTrainingPollCommandHandlerImpl{
+			CommandHandlerImpl: CommandHandlerImpl{
+				command: BOT_COMMAND_NEW_TRAINING_POLL,
 			},
 		},
 	}
@@ -28,5 +34,10 @@ type CommandHandlerImpl struct {
 
 // StartCommandHandlerImpl is a CommandHandler interface implementation that handles the "/start" command.
 type StartCommandHandlerImpl struct {
+	CommandHandlerImpl
+}
+
+// NewTrainingPollCommandHandlerImpl is a CommandHandler interface implementation that handles the "/start" command.
+type NewTrainingPollCommandHandlerImpl struct {
 	CommandHandlerImpl
 }


### PR DESCRIPTION
Part of #104.

This diff enables basic command functionality for `/newtrainingpoll`.

When triggered, the command can print a basic template for a training poll.

No callback buttons are enabled yet, and training poll data has yet to be auto-populated.
