### PR TITLE
Update infra bucket keys in CI IAM policies

### DIFF
--- a/ci/terraform/data.tf
+++ b/ci/terraform/data.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "terraform_state_management_policy" {
     ]
 
     resources = [
-      "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key}",
+      "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key_prd}",
       "${local.state_store_bucket_arn}/${local.ci_workspace_bucket_key}"
     ]
   }

--- a/ci/terraform/data.tf
+++ b/ci/terraform/data.tf
@@ -14,6 +14,7 @@ data "aws_iam_policy_document" "terraform_state_management_policy" {
 
     resources = [
       "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key_prd}",
+      "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key_old}",
       "${local.state_store_bucket_arn}/${local.ci_workspace_bucket_key}"
     ]
   }

--- a/ci/terraform/locals.tf
+++ b/ci/terraform/locals.tf
@@ -4,4 +4,5 @@ locals {
   infra_workspace_bucket_key_prd = "bball8bot/infra/prd/terraform.tfstate"
   ci_workspace_bucket_key        = "bball8bot/ci/terraform.tfstate"
   state_lock_table_arn           = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
+  infra_workspace_bucket_key_old = "bball8bot/infra/terraform.tfstate"
 }

--- a/ci/terraform/locals.tf
+++ b/ci/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  github_oidc_provider_url   = "token.actions.githubusercontent.com"
-  state_store_bucket_arn     = "arn:aws:s3:::jl-terraform-remote-state-store"
-  infra_workspace_bucket_key = "bball8bot/infra/terraform.tfstate"
-  ci_workspace_bucket_key    = "bball8bot/ci/terraform.tfstate"
-  state_lock_table_arn       = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
+  github_oidc_provider_url       = "token.actions.githubusercontent.com"
+  state_store_bucket_arn         = "arn:aws:s3:::jl-terraform-remote-state-store"
+  infra_workspace_bucket_key_prd = "bball8bot/infra/prd/terraform.tfstate"
+  ci_workspace_bucket_key        = "bball8bot/ci/terraform.tfstate"
+  state_lock_table_arn           = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
 }


### PR DESCRIPTION
This diff supports #120.

To migrate a Terraform workspace's state keys, the CI role needs access to both the new and old state bucket keys. 