### PR TITLE
Remove old infra Terraform state bucket key from CI IAM policies

### DIFF
--- a/ci/terraform/data.tf
+++ b/ci/terraform/data.tf
@@ -14,7 +14,6 @@ data "aws_iam_policy_document" "terraform_state_management_policy" {
 
     resources = [
       "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key_prd}",
-      "${local.state_store_bucket_arn}/${local.infra_workspace_bucket_key_old}",
       "${local.state_store_bucket_arn}/${local.ci_workspace_bucket_key}"
     ]
   }

--- a/ci/terraform/locals.tf
+++ b/ci/terraform/locals.tf
@@ -4,5 +4,4 @@ locals {
   infra_workspace_bucket_key_prd = "bball8bot/infra/prd/terraform.tfstate"
   ci_workspace_bucket_key        = "bball8bot/ci/terraform.tfstate"
   state_lock_table_arn           = "arn:aws:dynamodb:ap-southeast-1:574182556674:table/terraform_state_lock"
-  infra_workspace_bucket_key_old = "bball8bot/infra/terraform.tfstate"
 }


### PR DESCRIPTION
Clean up after #121 and #120 are landed.