### PR TITLE
Enable auto date population of Saturday training poll details

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -38,6 +38,12 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 		timeContent     string = "0915 - 1215"
 		locationContent string = "NTU"
 	)
+
+	upcomingSaturday := getUpcomingDate(time.Saturday)
+	dayContent = upcomingSaturday.Weekday().String()
+	y, m, d := upcomingSaturday.Date()
+	dateContent = fmt.Sprintf("%s %d, %d", m, d, y)
+
 	populatedTrainingPollTemplate := fmt.Sprintf(TRAINING_POLL_TEMPLATE, dayContent, dateContent, timeContent, locationContent)
 
 	escapeDashPopulatedTrainingPollTemplate := strings.Replace(populatedTrainingPollTemplate, "-", "\\-", -1)

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jonleeyz/bbball8bot/internal/logging"
 
@@ -41,6 +42,17 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 
 	escapeDashPopulatedTrainingPollTemplate := strings.Replace(populatedTrainingPollTemplate, "-", "\\-", -1)
 	return escapeDashPopulatedTrainingPollTemplate, nil
+}
+
+// getUpcomingDate returns the date of the next upcoming specified weekday.
+func getUpcomingDate(targetWeekday time.Weekday) time.Time {
+	currentDateTime := time.Now()
+	weekdayDiff := targetWeekday - currentDateTime.Weekday()
+	if weekdayDiff <= 0 {
+		weekdayDiff += 7
+	}
+
+	return currentDateTime.AddDate(0, 0, int(weekdayDiff))
 }
 
 const TRAINING_POLL_TEMPLATE = "*Training: %s, %s, %s @ %s*\n---\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"


### PR DESCRIPTION
This diff enables auto population of the date field with the next upcoming Saturday's date and day when a new training poll creation is requested.