### PR TITLE
Enable auto-population of upcoming Saturday training poll date information

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -38,6 +38,12 @@ func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Updat
 		timeContent     string = "0915 - 1215"
 		locationContent string = "NTU"
 	)
+
+	upcomingSaturday := getUpcomingDate(time.Saturday)
+	dayContent = upcomingSaturday.Weekday().String()
+	y, m, d := upcomingSaturday.Date()
+	dateContent = fmt.Sprintf("%s %d, %d", m, d, y)
+
 	populatedTrainingPollTemplate := fmt.Sprintf(TRAINING_POLL_TEMPLATE, dayContent, dateContent, timeContent, locationContent)
 
 	escapeDashPopulatedTrainingPollTemplate := strings.Replace(populatedTrainingPollTemplate, "-", "\\-", -1)


### PR DESCRIPTION
Part of https://github.com/jonleeyz/bball8bot/issues/104.

When "/newtrainingpoll" is triggered, the resultant poll returned contains auto-populated date information for the upcoming Saturday.