### PR TITLE
Fix nil message object panic

### DIFF
--- a/src/internal/logging/logging.go
+++ b/src/internal/logging/logging.go
@@ -49,6 +49,7 @@ func Debugf(message string, debugObjects ...interface{}) {
 
 func LogUpdateObject(update tgbotapi.Update) {
 	Printf("Update: %+v", update)
+	// TODO: Maybe make these debug level logs
 	Printf("Update - Message payload: %+v", update.Message)
 	Printf("Update - EditedMessage payload: %+v", update.EditedMessage)
 	Printf("Update - InlineQuery payload: %+v", update.InlineQuery)

--- a/src/main.go
+++ b/src/main.go
@@ -19,7 +19,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 	if event == nil {
 		errMessage := "error: event is nil"
 		logging.Fatal(errMessage)
-		return fmt.Errorf(errMessage)
+		return fmt.Errorf("%s", errMessage)
 	}
 
 	token, err := secrets.GetBotToken()

--- a/src/main.go
+++ b/src/main.go
@@ -59,7 +59,6 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
 		if _, err := bot.Send(newReply); err != nil {
 			logging.Printf("error when calling Telegram Bot API to send message: %v", err)
-			continue
 		}
 	}
 	return nil

--- a/src/main.go
+++ b/src/main.go
@@ -45,6 +45,10 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			logging.LogUpdateObject(*update)
 		}
 
+		if update.Message == nil {
+			continue
+		}
+
 		// if message is command, call command handler
 		if update.Message.IsCommand() {
 			return commands.HandleBotCommand(ctx, bot, update)


### PR DESCRIPTION
`nil` `Message` objects in `Updates` were being dereferenced.

> 2025/03/13 16:41:40 
{
    "errorMessage": "runtime error: invalid memory address or nil pointer dereference",
    "errorType": "errorString",
    "stackTrace": [
        ...
        {
            "path": "github.com/go-telegram-bot-api/telegram-bot-api/v5@v5.5.1/types.go",
            "line": 633,
            "label": "(*Message).IsCommand"
        },
        {
            "path": "src/main.go",
            "line": 49,
            "label": "HandleRequest"
        },
        ...
    ]
}