### PR TITLE
Remove duplicate error logging

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -25,10 +25,7 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 	trainingPollMessageResponse.ReplyMarkup = buildInlineKeyboard()
 
 	if _, err := h.bot.Send(trainingPollMessageResponse); err != nil {
-		err = fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)
-
-		logging.Infof(err.Error())
-		return err
+		return fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Each error is being logged twice in CloudWatch; this diff addresses this.