### PR TITLE
Update sendMessage error logging

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -25,7 +25,11 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 	trainingPollMessageResponse.ReplyMarkup = buildInlineKeyboard()
 
 	if _, err := h.bot.Send(trainingPollMessageResponse); err != nil {
-		return fmt.Errorf("error when calling Telegram Bot API to send message: %v", err)
+		logging.Errorf(
+			"error when calling Telegram Bot API to send /newtrainingpoll response.\n MessageConfig object: %+v",
+			trainingPollMessageContent,
+		)
+		return err
 	}
 	return nil
 }

--- a/src/internal/logging/logging.go
+++ b/src/internal/logging/logging.go
@@ -50,7 +50,7 @@ func Debugf(message string, debugObjects ...interface{}) {
 	}
 
 	debugLog := fmt.Sprintf(message, debugObjects...)
-	log.Printf("[MANUAL_DEBUG_LOG] %s", debugLog)
+	log.Printf("[DEBUG] %s", debugLog)
 }
 
 func LogUpdateObject(update tgbotapi.Update) {

--- a/src/internal/logging/logging.go
+++ b/src/internal/logging/logging.go
@@ -37,6 +37,12 @@ func Fatalf(errMessage string, debugObjects ...interface{}) {
 	log.Fatalf(errMessage, debugObjects...)
 }
 
+// Errorf is a syntatic wrapper around the log.Printf function that creates a log entry with error tags.
+func Errorf(errMessage string, debugObjects ...interface{}) {
+	errorLog := fmt.Errorf(errMessage, debugObjects...)
+	log.Printf("[ERROR] %s", errorLog)
+}
+
 // Debugf is a syntatic wrapper around the log.Printf function that creates a log entry with debug tags.
 func Debugf(message string, debugObjects ...interface{}) {
 	if !IS_DEBUG_LOGGING_ENABLED {


### PR DESCRIPTION
Updated logging when `sendMessage` errors; `Message` struct is now logged.