### PR TITLE
Update inline keyboard implementations to return callback queries

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -79,12 +79,12 @@ func addEscapeTokens(trainingPollMessageContent string) string {
 func buildInlineKeyboard() tgbotapi.InlineKeyboardMarkup {
 	return tgbotapi.NewInlineKeyboardMarkup(
 		tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData("test1", ""),
-			tgbotapi.NewInlineKeyboardButtonData("test2", ""),
+			tgbotapi.NewInlineKeyboardButtonData("test1", CALLBACK_QUERY_BUTTON_PRESSED),
+			tgbotapi.NewInlineKeyboardButtonData("test2", CALLBACK_QUERY_BUTTON_PRESSED),
 		),
 		tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData("test3", ""),
-			tgbotapi.NewInlineKeyboardButtonData("test4", ""),
+			tgbotapi.NewInlineKeyboardButtonData("test3", CALLBACK_QUERY_BUTTON_PRESSED),
+			tgbotapi.NewInlineKeyboardButtonData("test4", CALLBACK_QUERY_BUTTON_PRESSED),
 		),
 	)
 }

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -97,3 +97,4 @@ type trainingPollContent struct {
 }
 
 const TRAINING_POLL_TEMPLATE = "*Regular practice\n%s, %s, \n%s\n%s*\n==========\n\n\n*Attending:*\n\n\n*Not attending:*\n\n\n*Checking availability:*\n\n\n*Yet to respond:*\n\n\n"
+const CALLBACK_QUERY_BUTTON_PRESSED = "CALLBACK_QUERY_BUTTON_PRESSED"


### PR DESCRIPTION
An inline keyboard button is invalid if there is no URL or callback query attached to it.

This diff adds a simple callback query to be returned by each button.

Callback queries will need to be handled in future changes.