### PR TITLE
Add primitive callback query answering logic

### DIFF
--- a/src/internal/json/unmarshal.go
+++ b/src/internal/json/unmarshal.go
@@ -25,7 +25,7 @@ func GetTelegramUpdateFromSQSMessage(sqsMessage events.SQSMessage) (*tgbotapi.Up
 		logging.Infof("error when unmarshaling Telegram Update object: %v", err)
 		return nil, err
 	}
-	logging.Debugf("Unmarshal sqsMessageBody post-unmarshal: %+v", unmarshaledSQSMessageBody)
+	logging.Errorf("Unmarshal sqsMessageBody post-unmarshal: %+v", unmarshaledSQSMessageBody)
 
 	// 3. Return Update object
 	return &unmarshaledSQSMessageBody.Body, nil

--- a/src/internal/logging/logging.go
+++ b/src/internal/logging/logging.go
@@ -53,9 +53,9 @@ func Debugf(message string, debugObjects ...interface{}) {
 	log.Printf("[DEBUG] %s", debugLog)
 }
 
+// TODO: tweak to take pointer of Update object
 func LogUpdateObject(update tgbotapi.Update) {
 	Infof("Update: %+v", update)
-	// TODO: Maybe make these debug level logs
 	Debugf("Update - Message payload: %+v", update.Message)
 	Debugf("Update - EditedMessage payload: %+v", update.EditedMessage)
 	Debugf("Update - InlineQuery payload: %+v", update.InlineQuery)

--- a/src/main.go
+++ b/src/main.go
@@ -40,7 +40,8 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 	for _, sqsMessage := range event.Records {
 		update, err := json.GetTelegramUpdateFromSQSMessage(sqsMessage)
 		if err != nil {
-			logging.Infof("error when unmarshaling SQS message: %v", err)
+			logging.Errorf("error when unmarshaling SQS message: %v", err)
+			continue
 		} else {
 			logging.LogUpdateObject(*update)
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -45,6 +45,20 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			logging.LogUpdateObject(*update)
 		}
 
+		// TODO @jonlee: Update, placeholder, just to ensure that callback queries are answered.
+		if update.CallbackQuery != nil {
+			callback := update.CallbackQuery
+			callbackResponseString := fmt.Sprintf("button pressed: %s", callback.Data)
+			callbackTemplateReply := tgbotapi.NewMessage(update.Message.Chat.ID, callbackResponseString)
+			bot.Send(callbackTemplateReply)
+
+			callbackAnswer := tgbotapi.NewCallbackWithAlert(callback.ID, callbackResponseString)
+			if _, err := bot.Send(callbackAnswer); err != nil {
+				logging.Errorf("error when answering callback: %v", err)
+			}
+			continue
+		}
+
 		if update.Message == nil {
 			continue
 		}


### PR DESCRIPTION
This diff adds primitive callback query answering logic, so that all callback queries received by the Bot are answered using `answerCallbackQuery`, as required (https://core.telegram.org/bots/api#callbackquery).