### PR TITLE
Fix nil dereference when handling callback queries

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -52,7 +52,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		if update.CallbackQuery != nil {
 			callback := update.CallbackQuery
 			callbackResponseString := fmt.Sprintf("button pressed: %s", callback.Data)
-			callbackTemplateReply := tgbotapi.NewMessage(update.Message.Chat.ID, callbackResponseString)
+			callbackTemplateReply := tgbotapi.NewMessage(callback.From.ID, callbackResponseString)
 			bot.Send(callbackTemplateReply)
 
 			callbackAnswer := tgbotapi.NewCallbackWithAlert(callback.ID, callbackResponseString)


### PR DESCRIPTION
Each Update only will contain exactly 1 of `Message`, `CallbackQuery`, or other types.

If flow is handling a `CallbackQuery`, `Message` will be nil, and hence should not be dereferenced.