### PR TITLE
Use bot.Request for AnswerCallbackQuery

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -74,8 +74,8 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		// if message is not command, echo message as reply to original message
 		newReply := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
-		if _, err := bot.Send(newReply); err != nil {
-			logging.Infof("error when calling Telegram Bot API to send message: %v", err)
+		if _, err := bot.Request(newReply); err != nil {
+			logging.Errorf("error when calling Telegram Bot API to send message: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
The response for `AnswerCallbackQuery` cannot be and should not be coerced to a `Message` object.

The appropriate `Bot` method to use should hence be `Request`, as `Send` calls `Request` anyway, and coerces the result to a `Message` object, which causes an error.