### PR TITLE
Update main handler implementation to log command handler errors

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -68,7 +68,11 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 
 		// if message is command, call command handler
 		if update.Message.IsCommand() {
-			return commands.HandleBotCommand(ctx, bot, update)
+			if err := commands.HandleBotCommand(ctx, bot, update); err != nil {
+				// TODO @jonlee: Tidy this log statement
+				logging.Errorf("TEMP TOP level log: %v", err)
+				continue
+			}
 		}
 
 		// if message is not command, echo message as reply to original message


### PR DESCRIPTION
The diff updates the main handler implementation to log command handler errors instead of returning early.

Previous implementation returned immediately, which might cause updates that have been pulled from the SQS to be left unprocessed.