### PR TITLE
Fix errors when unmarshaling Telegram API responses

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -78,7 +78,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		// if message is not command, echo message as reply to original message
 		newReply := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
-		if _, err := bot.Request(newReply); err != nil {
+		if _, err := bot.Send(newReply); err != nil {
 			logging.Errorf("error when calling Telegram Bot API to send message: %v", err)
 		}
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -56,7 +56,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			bot.Send(callbackTemplateReply)
 
 			callbackAnswer := tgbotapi.NewCallbackWithAlert(callback.ID, callbackResponseString)
-			if _, err := bot.Send(callbackAnswer); err != nil {
+			if _, err := bot.Request(callbackAnswer); err != nil {
 				logging.Errorf("error when answering callback: %v", err)
 			}
 			continue


### PR DESCRIPTION
`bot.Request` should be used for calling the `answerCallbackQuery` endpoint, as the result cannot be unmarshaled into a Go object.

Otherwise, use `bot.Send`.