### PR TITLE
Update /newtrainingpoll handler implementation to return simple test message body

### DIFF
--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -13,7 +13,8 @@ import (
 
 // Handle initiates the handling flow for the "/newtrainingpoll" command.
 func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
-	trainingPollMessageContent, err := buildTrainingPollMessageContent(ctx, h.update)
+	// trainingPollMessageContent, err := buildTrainingPollMessageContent(ctx, h.update)
+	trainingPollMessageContent, err := provideSimpleTestTrainingPollMessageContent(ctx)
 	if err != nil {
 		return err
 	}

--- a/src/internal/commands/new_training_poll_impl.go
+++ b/src/internal/commands/new_training_poll_impl.go
@@ -34,6 +34,13 @@ func (h *NewTrainingPollCommandHandlerImpl) Handle(ctx context.Context) error {
 	return nil
 }
 
+// TODO @jonlee: Delete once tests are complete
+// provideSimpleTestTrainingPollMessageContent builds a simple content string for testing purposes.
+func provideSimpleTestTrainingPollMessageContent(ctx context.Context) (string, error) {
+	messageContent := "hallo chat from Maki15Pro"
+	return messageContent, nil
+}
+
 // buildTrainingPollMessageContent builds the content string for a training poll message.
 func buildTrainingPollMessageContent(ctx context.Context, update *tgbotapi.Update) (string, error) {
 	content := generateTrainingPollContent(time.Saturday)


### PR DESCRIPTION
This diff tweaks the `/newtrainingpoll` handler implementation to return a poll message with a simple test message body.

This is to facilitate further examination of #144.