### PR TITLE
Add logging to trace program flow in main driver function

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -49,6 +49,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		}
 
 		// TODO @jonlee: Update, placeholder, just to ensure that callback queries are answered.
+		logging.Debugf("BEFORE CALLBACK QUERY HANDLING BLOCK")
 		if update.CallbackQuery != nil {
 			callback := update.CallbackQuery
 			callbackResponseString := fmt.Sprintf("button pressed: %s", callback.Data)
@@ -66,6 +67,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			continue
 		}
 
+		logging.Debugf("BEFORE COMMAND HANDLING BLOCK")
 		// if message is command, call command handler
 		if update.Message.IsCommand() {
 			if err := commands.HandleBotCommand(ctx, bot, update); err != nil {
@@ -76,6 +78,7 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		}
 
 		// if message is not command, echo message as reply to original message
+		logging.Debugf("BEFORE MISC MESSAGE HANDLING BLOCK")
 		newReply := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
 		if _, err := bot.Send(newReply); err != nil {


### PR DESCRIPTION
Inline buttons are now triggered callbacks successfully after #145 was landed.

However, the bot is also repeating command phrases when they are being sent, which is only expected to happen when the user sends a non-command input.

Logging is added in this diff to address this regression.