### PR TITLE
Fix echoing of command literals

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -49,7 +49,6 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		}
 
 		// TODO @jonlee: Update, placeholder, just to ensure that callback queries are answered.
-		logging.Debugf("BEFORE CALLBACK QUERY HANDLING BLOCK")
 		if update.CallbackQuery != nil {
 			callback := update.CallbackQuery
 			callbackResponseString := fmt.Sprintf("button pressed: %s", callback.Data)
@@ -67,7 +66,6 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			continue
 		}
 
-		logging.Debugf("BEFORE COMMAND HANDLING BLOCK")
 		// if message is command, call command handler
 		if update.Message.IsCommand() {
 			if err := commands.HandleBotCommand(ctx, bot, update); err != nil {
@@ -78,7 +76,6 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 		}
 
 		// if message is not command, echo message as reply to original message
-		logging.Debugf("BEFORE MISC MESSAGE HANDLING BLOCK")
 		newReply := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 		newReply.BaseChat.ReplyToMessageID = update.Message.MessageID
 		if _, err := bot.Send(newReply); err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -73,8 +73,8 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 			if err := commands.HandleBotCommand(ctx, bot, update); err != nil {
 				// TODO @jonlee: Tidy this log statement
 				logging.Errorf("TEMP TOP level log: %v", err)
-				continue
 			}
+			continue
 		}
 
 		// if message is not command, echo message as reply to original message


### PR DESCRIPTION
This diff fixes unexpected behavior, where command literals were being echoed back to the user, as non-command literals should be.

----

#### Expected behaviour:
- If a command literal (eg. `/start`, `/newtrainingpoll`) is sent to the bot as input, the bot should handle it as a command.
- If a non-command literal is sent, the bot should echo the literal.
- Only one of those two should happen.

#### What was happening:
- Bot was handling command literals correctly, but also echoing them.

