### PR TITLE
Add TODO context to requests

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -91,5 +91,5 @@ func HandleRequest(ctx context.Context, event *events.SQSEvent) error {
 
 func main() {
 	logging.Init()
-	lambda.Start(HandleRequest)
+	lambda.StartWithOptions(HandleRequest, lambda.WithContext(context.TODO()))
 }


### PR DESCRIPTION
Contexts are not explicitly needed now, but will be useful if goroutines need to spun off later.

The recommendation is to use `context.TODO()` if there is a lack of clarity of how to handle contexts in a development setting, hence this diff.