### PR TITLE
Refactor: Rename getUpdateHandler -> createUpdateHandler

### DIFF
--- a/src/internal/handlers/get_update_handler.go
+++ b/src/internal/handlers/get_update_handler.go
@@ -17,10 +17,10 @@ import (
  * Reference: (https://core.telegram.org/bots/api#update)
  */
 
-// getUpdateHandler returns a new handler instance suitable to handle the input Update's content.
+// createUpdateHandler returns a new handler instance suitable to handle the input Update's content.
 // Pre-condition: Exactly 1 optional field in an Update object will be non-nil.
 // Updates provided by Telegram backend are guaranteed to fulfill this pre-condition.
-func getUpdateHandler(ctx context.Context, bot *tgbotapi.BotAPI, update *tgbotapi.Update) (UpdateHandler, error) {
+func createUpdateHandler(ctx context.Context, bot *tgbotapi.BotAPI, update *tgbotapi.Update) (UpdateHandler, error) {
 	if isUpdateACallbackQuery(update) {
 		return callbacks.Init(bot, update)
 	}

--- a/src/internal/handlers/main.go
+++ b/src/internal/handlers/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func HandleUpdate(ctx context.Context, update *tgbotapi.Update, bot *tgbotapi.BotAPI) error {
-	h, err := getUpdateHandler(ctx, bot, update)
+	h, err := createUpdateHandler(ctx, bot, update)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous `getUpdateHandler` name was potentially confusing:

As the output of `getUpdateHandler` would have subsumed and encapsulated the `Update` input object, the naming was unintuitive. 