### PR TITLE
Update "ATTENDING" callback handling logic to use training poll assembler

### DIFF
--- a/src/internal/assemblers/training_polls.go
+++ b/src/internal/assemblers/training_polls.go
@@ -1,0 +1,61 @@
+package assemblers
+
+import (
+	"context"
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	customerrors "github.com/jonleeyz/bball8bot/internal/util/custom-errors"
+)
+
+// GetEditMessageConfigForNewAttendee outputs the edit message object that should reflect a training poll's correctly updated
+// message body after an ATTENDING callback query is received.
+func GetEditMessageConfigForAttendingCallback(
+	ctx context.Context, callbackQuery *tgbotapi.CallbackQuery) (*tgbotapi.EditMessageTextConfig, error) {
+
+	if callbackQuery == nil {
+		return nil, getEditForAttendingError(customerrors.ERROR_NIL_CALLBACK)
+	}
+	if callbackQuery.Message == nil {
+		return nil, getEditForAttendingError(customerrors.ERROR_NIL_CALLBACK_MESSAGE)
+	}
+	if callbackQuery.From == nil {
+		return nil, getEditForAttendingError(customerrors.ERROR_NIL_CALLBACK_USER)
+	}
+
+	updatedMessageBody, err := generateUpdatedMessageBodyTextReflectingNewlyAttendingUser(
+		ctx, callbackQuery.Message.Text, callbackQuery.From)
+	if err != nil {
+		return nil, err
+	}
+
+	editMessage := tgbotapi.EditMessageTextConfig{
+		BaseEdit: tgbotapi.BaseEdit{
+			ChatID:      callbackQuery.From.ID,
+			MessageID:   callbackQuery.Message.MessageID,
+			ReplyMarkup: callbackQuery.Message.ReplyMarkup,
+		},
+
+		Text:      updatedMessageBody,
+		ParseMode: tgbotapi.ModeMarkdownV2,
+		// TODO @jonlee: Try entities
+	}
+	return &editMessage, nil
+}
+
+// generateUpdatedMessageBodyTextReflectingNewlyAttendingUser updates the input training poll message body text to reflect that
+// the input user has indicated "attending".
+// TODO @jonlee: Should not update by referring to previous text; should update poll stored state and then reconstruct.
+func generateUpdatedMessageBodyTextReflectingNewlyAttendingUser(
+	ctx context.Context, trainingPollMessageBodyText string, user *tgbotapi.User) (string, error) {
+
+	if user == nil {
+		return "", createNewAttendeeUpdatedMessageBodyError(customerrors.ERROR_NIL_USER)
+	}
+
+	userHandle := user.String()
+	return fmt.Sprintf("%s\n%s", trainingPollMessageBodyText, userHandle), nil
+}
+
+var getEditForAttendingError = customerrors.CreateErrorTemplate("error when getting edit message for attending callback: %s")
+var createNewAttendeeUpdatedMessageBodyError = customerrors.CreateErrorTemplate("error when generating updated message body with new attending user: %s")

--- a/src/internal/handlers/callbacks/attending.go
+++ b/src/internal/handlers/callbacks/attending.go
@@ -55,13 +55,3 @@ func (h *CallbackQueryHandler) answerAttendingCallback(ctx context.Context) erro
 	}
 	return nil
 }
-
-// TODO @jonlee: To properly implement
-func appendAttendeeNameToAttendingSection(pollMessageBody, attendeeName string) string {
-	return fmt.Sprintf("%s\n%s", pollMessageBody, attendeeName)
-}
-
-// TODO @jonlee: To implement dynamically
-func (h *CallbackQueryHandler) getAttendeeName() string {
-	return h.callbackQuery.From.UserName
-}

--- a/src/internal/handlers/callbacks/attending.go
+++ b/src/internal/handlers/callbacks/attending.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/jonleeyz/bball8bot/internal/assemblers"
 	"github.com/jonleeyz/bball8bot/internal/util/logging"
 )
 
@@ -22,23 +23,12 @@ func (h *CallbackQueryHandler) handleAttendingCallback(ctx context.Context) erro
 }
 
 func (h *CallbackQueryHandler) addAttendeeNameToPollMessageBody(ctx context.Context) error {
-	// create edit message
-	attendeeName := h.getAttendeeName()
-	editMessage := tgbotapi.EditMessageTextConfig{
-		BaseEdit: tgbotapi.BaseEdit{
-			ChatID:      h.callbackQuery.From.ID,
-			MessageID:   h.callbackQuery.Message.MessageID,
-			ReplyMarkup: h.callbackQuery.Message.ReplyMarkup,
-		},
-
-		// TODO @jonlee: Ideally should not append by referring to previous text; should reconstruct and update poll from stored state.
-		Text:      appendAttendeeNameToAttendingSection(h.callbackQuery.Message.Text, attendeeName),
-		ParseMode: tgbotapi.ModeMarkdownV2,
-		// TODO @jonlee: Try entities
+	editMessage, err := assemblers.GetEditMessageConfigForAttendingCallback(ctx, h.callbackQuery)
+	if err != nil {
+		return err
 	}
 
-	// send edit message
-	_, err := h.bot.Send(editMessage)
+	_, err = h.bot.Send(editMessage)
 	logging.Debugf("edit message attempted; edit message body: %+v", editMessage)
 
 	if err != nil {


### PR DESCRIPTION
This diff:
- Creates an assembler package that handles all necessary message text creation and updates to training poll messages.
- Updates the "ATTENDING" callback handling implementation to use said assembler.